### PR TITLE
Switch to ULID for ID generations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.21.2", features = ["sync", "time"] }
 tower = { version = "0.4.13", features = ["util"] }
 tower-http = { version = "0.3.4", features = ["cors", "limit", "set-header"] }
 tracing = "0.1.37"
-uuid = { version = "1.1.2", features = ["v4", "fast-rng", "serde"] }
+ulid = { version = "1.0.0", features = ["serde"] }
 
 [dev-dependencies]
 hyper = "0.14.20"


### PR DESCRIPTION
IDs look like this with ULIDs: `01GF8GKCDT0HMMJ606KCQBV2ZJ`
I can format them as UUID if necessary (since they are also 128bit), but this is probably unnecessary.

It's virtually not possible to cause collisions with them, since they include a ms timestamp + 80bit of randomness

@hughns merge if you think it makes sense